### PR TITLE
Fix psycopg version compatibility for Render deployment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,5 @@ pydantic-core==2.20.1
 python-dotenv==1.0.1
 orjson==3.10.7
 diskcache==5.6.3
-psycopg[binary]==3.1.19
+psycopg[binary]==3.2.9
 SQLAlchemy==2.0.32


### PR DESCRIPTION
- Update psycopg[binary] from 3.1.19 to 3.2.9
- Resolves build failure: 'Could not find a version that satisfies the requirement psycopg-binary==3.1.19'
- Available versions on Render are 3.2.2 through 3.2.9